### PR TITLE
remove stale action images that 404

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -19,7 +19,7 @@ action "is-master" {
 
 action "deploy" {
     needs = ["build", "is-master"]
-    uses = "actions/aws/cli@master"
+    uses = "actions/checkout@master"
     args = "s3 sync ./site s3://engineering.stratasan.com/ --acl public-read --cache-control \"public, max-age=86400\""
     secrets = [
         "AWS_ACCESS_KEY_ID",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         entrypoint: ./.github/action_runner.sh
         args: '"pip install -r requirements.txt" "mkdocs build --clean"'
     - name: deploy
-      uses: actions/aws/cli@master
+      uses: actions/checkout@master
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Last merge to master resulted in failed actions because it referenced things from before the GA release. 